### PR TITLE
Fixed issue when config string is not found in fpga_config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,6 @@ Release History
    - Removed
    - Fixed
 
-
 0.1.1 (Unreleased)
 ------------------
 
@@ -55,7 +54,6 @@ Release History
 - Added script to read device DNA from FPGA board.
   (`#11 <https://github.com/nengo/nengo-fpga/pull/11>`__)
 
-
 **Changed**
 
 - Update the docs theme.
@@ -69,6 +67,12 @@ Release History
 
 - Rename "DNA" to "ID" everywhere.
   (`#20 <https://github.com/nengo/nengo-fpga/pull/20>`__)
+
+**Fixed**
+
+- Fixed behaviour of code when provided FPGA name string is not found in the
+  fpga_config file.
+  (`#33 <https://github.com/nengo/nengo-fpga/pull/33>`__)
 
 
 0.1.0 (December 19, 2018)

--- a/nengo_fpga/networks/fpga_pes_ensemble_network.py
+++ b/nengo_fpga/networks/fpga_pes_ensemble_network.py
@@ -196,16 +196,28 @@ class FpgaPesEnsembleNetwork(nengo.Network):
         return os.path.join(self.arg_data_path, self.arg_data_file)
 
     def close(self):
+        # Function does nothing if FPGA configuration not found in config file
+        if not self.config_found:
+            return
+
         logger.info("<%s> SSH connection closed" %
                     fpga_config.get(self.fpga_name, 'ip'))
         self.ssh_client.close()
 
     def cleanup(self):
+        # Function does nothing if FPGA configuration not found in config file
+        if not self.config_found:
+            return
+
         # Clean up any existing argument data files
         if os.path.exists(self.local_data_filepath):
             os.remove(self.local_data_filepath)
 
     def connect_thread_func(self):
+        # Function does nothing if FPGA configuration not found in config file
+        if not self.config_found:
+            return
+
         # Get the IP of the remote device from the fpga_config file
         remote_ip = fpga_config.get(self.fpga_name, 'ip')
 
@@ -326,6 +338,10 @@ class FpgaPesEnsembleNetwork(nengo.Network):
                     % (remote_ip, '\n'.join(error_strs)))
 
     def connect(self):
+        # Function does nothing if FPGA configuration not found in config file
+        if not self.config_found:
+            return
+
         logger.info("<%s> Open SSH connection" %
                     fpga_config.get(self.fpga_name, 'ip'))
         # Start a new thread to open the ssh connection. Use a thread to
@@ -348,6 +364,12 @@ class FpgaPesEnsembleNetwork(nengo.Network):
         self.ssh_info_str += str_data
 
     def reset(self):
+        # Function does nothing if FPGA configuration not found in config file
+        if not self.config_found:
+            return
+
+        # Otherwise, close and reopen the SSH connection to the board
+        # Closing the SSH connection will terminate the board-side script
         logger.info("<%s> Resetting SSH connection:" %
                     fpga_config.get(self.fpga_name, 'ip'))
         # Close and reopen ssh connections
@@ -378,7 +400,6 @@ class FpgaPesEnsembleNetwork(nengo.Network):
 def build_FpgaPesEnsembleNetwork(model, network):
     """ Add build steps like nengo?
     """
-
 
     # Check if nengo_fpga.Simulator is being used to build this network
     if not network.using_fpga_sim:


### PR DESCRIPTION
Added additional checks to functions that get information from the fpga_config file.

**Motivation and context:**
Before this fix, if the provided string was not found in the fpga_config file, the simulator would terminate prematurely, instead of continuing with the simulation with the default nengo simulator. This fix addresses this issue and the code now functions as intended.

**Interactions with other PRs:**
None

**How has this been tested?**
- [x] Code runs using the default nengo simulator when provided fpga name is not found in the fpga_config file.
- [x] Code runs using the nengo-fpga simulator when provided fpga name is found in the fpga_config file.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
Look in the networks/fpga_pes_ensemble_network.py file.

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have tested this with all supported devices.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
