### PR TITLE
Fixed sequential simulation runs hanging issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,10 @@ Release History
   fpga_config file.
   (`#33 <https://github.com/nengo/nengo-fpga/pull/33>`__)
 
+- Fixed simulation hanging error when two simulations are run one after the
+  other.
+  (`#34 <https://github.com/nengo/nengo-fpga/pull/34>`__)
+
 
 0.1.0 (December 19, 2018)
 -------------------------

--- a/nengo_fpga/networks/fpga_pes_ensemble_network.py
+++ b/nengo_fpga/networks/fpga_pes_ensemble_network.py
@@ -205,6 +205,13 @@ class FpgaPesEnsembleNetwork(nengo.Network):
         if not self.config_found:
             return
 
+        # Close the UDP socket if it is open
+        if self.udp_socket is not None:
+            logger.info("<%s> UDP Connection closed" %
+                        fpga_config.get(self.fpga_name, 'ip'))
+            self.udp_socket.close()
+
+        # Close the SSH connection
         logger.info("<%s> SSH connection closed" %
                     fpga_config.get(self.fpga_name, 'ip'))
         self.ssh_client.close()


### PR DESCRIPTION
**Motivation and context:**
The UDP socket created in one simulation is closed only when the second simulation is started (not when the first is closed). This, however, does not happen on windows, instead the first socket remains open and all packets get routed to that instead of to the second one (causing the second simulation to hang). This PR fixes this issue.

**How has this been tested?**
Tested creating two sequentially executed NengoFPGA simulations on windows and linux boxes.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
Bug fix (non-breaking change which fixes an issue):
- Added close method for UDP socket processes
- Modified FpgaPesEnsembleNetwork to call UDP socket process close method when the simulator object is closed


**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x ] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have tested this with all supported devices.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
