### PR TITLE
Added spiking to feedback notebooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Release History
 - Added notebook examples featuring oscillators.
   (`#46 <https://github.com/nengo/nengo-fpga/pull/46>`__)
 
+- Added spiking to oscillator notebook examples.
+  (`#49 <https://github.com/nengo/nengo-fpga/pull/49>`__)
+
 **Changed**
 
 - Compatibility changes for Nengo 3.0.0.

--- a/docs/examples/notebooks/03-integrator.ipynb
+++ b/docs/examples/notebooks/03-integrator.ipynb
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 8: Plot the Results:"
+    "## Step 8: Plot the Results"
    ]
   },
   {
@@ -211,17 +211,76 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(8, 5))\n",
-    "plt.plot(sim.trange(), sim.data[input_p], 'k--', label=\"Input\")\n",
-    "plt.plot(sim.trange(), sim.data[output_p], label=\"Integrator output\")\n",
-    "plt.legend();"
+    "def plot_results():\n",
+    "    plt.figure(figsize=(8, 5))\n",
+    "    plt.plot(sim.trange(), sim.data[input_p], 'k--', label=\"Input\")\n",
+    "    plt.plot(sim.trange(), sim.data[output_p], label=\"Integrator output\")\n",
+    "    plot_ideal()\n",
+    "    plt.legend();\n",
+    "\n",
+    "\n",
+    "def plot_ideal():\n",
+    "    # Obtain the input function data from the input_node\n",
+    "    input_t = list(input_node.output.data.keys())\n",
+    "    input_v = list(input_node.output.data.values())\n",
+    "\n",
+    "    # Construct the ideal output (assumes 1D signal)\n",
+    "    values = [[0]]\n",
+    "    input_t += [sim.trange()[-1]]\n",
+    "    for i, v in enumerate(input_v):\n",
+    "        values += [values[-1] + v * (input_t[i + 1] - input_t[i])]\n",
+    "\n",
+    "    # Make the plot\n",
+    "    plt.plot(input_t, values, label=\"Ideal\")\n",
+    "\n",
+    "\n",
+    "plot_results()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot above shows the neurons effectively integrating the input signal. Because of the implementation in neurons, the integration is not perfect (i.e., there will be some drift). Run the simulation several times to get a sense of the kinds of drift you might expect.\n",
+    "The plot above shows the neurons effectively integrating the input signal. Because of the implementation in neurons, the integration is not perfect (i.e., there will be some drift). Run the simulation several times to get a sense of the kinds of drift you might expect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 9: Spiking Neurons\n",
+    "\n",
+    "The plots above demonstrate the results of an integrator network implemented with non-spiking rectified linear neurons. The network can also be simulated using spiking neurons to illustrate the similarities and differences between a spiking and a non-spiking network.\n",
+    "\n",
+    "Below, we configure the FPGA neural ensemble to use spiking neurons, run the simulation, and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with model:\n",
+    "    fpga_ens.ensemble.neuron_type = nengo.SpikingRectifiedLinear()\n",
+    "\n",
+    "with nengo_fpga.Simulator(model) as sim:\n",
+    "    sim.run(6)\n",
+    "plot_results()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot above shows that while the output differs from the non-spiking simulation (because the network parameters are regenerated when a new simulation is created), the performance of the spiking integrator still conforms to the expected output of an integrator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10: Experiment!\n",
     "\n",
     "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the drift)!"
    ]

--- a/docs/examples/notebooks/04-oscillator.ipynb
+++ b/docs/examples/notebooks/04-oscillator.ipynb
@@ -216,7 +216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 8: Plot the Results:"
+    "## Step 8: Plot the Results"
    ]
   },
   {
@@ -225,11 +225,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(8, 5))\n",
-    "plt.plot(sim.trange(), sim.data[input_p][:, 0], 'k--')\n",
-    "plt.plot(sim.trange(), sim.data[output_p])\n",
-    "plt.legend(['Kick', '$x_0$', '$x_1$'], loc='upper right')\n",
-    "plt.xlabel('Time (s)');"
+    "def plot_results():\n",
+    "    plt.figure(figsize=(8, 5))\n",
+    "    plt.plot(sim.trange(), sim.data[input_p][:, 0], 'k--')\n",
+    "    plt.plot(sim.trange(), sim.data[output_p])\n",
+    "    plt.legend(['Kick', '$x_0$', '$x_1$'], loc='upper right')\n",
+    "    plt.xlabel('Time (s)');\n",
+    "\n",
+    "\n",
+    "plot_results()"
    ]
   },
   {
@@ -247,16 +251,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax, anim = make_anim_simple_osc(sim.data[output_p][:, 0],\n",
-    "                                     sim.data[output_p][:, 1])\n",
-    "HTML(anim.to_html5_video())"
+    "def make_anim():\n",
+    "    _, _, anim = make_anim_simple_osc(sim.data[output_p][:, 0],\n",
+    "                                      sim.data[output_p][:, 1])\n",
+    "    return anim\n",
+    "\n",
+    "\n",
+    "HTML(make_anim().to_html5_video())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, modify the oscillation frequency (try making it negative) to its impact on the output. You can also change the simulation time and see how long the oscillator is stable for!"
+    "## Step 9: Spiking Neurons\n",
+    "\n",
+    "The plots above demonstrate the results of a simple oscillator implemented in a network of non-spiking rectified linear neurons. The network can also be simulated using spiking neurons to illustrate the similarities and differences between a spiking and a non-spiking network.\n",
+    "\n",
+    "Below, we configure the FPGA neural ensemble to use spiking neurons, run the simulation, and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with model:\n",
+    "    fpga_ens.ensemble.neuron_type = nengo.SpikingRectifiedLinear()\n",
+    "\n",
+    "with nengo_fpga.Simulator(model) as sim:\n",
+    "    sim.run(5)\n",
+    "plot_results()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HTML(make_anim().to_html5_video())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plots above show that with spiking neurons, the output of the network is, expectedly, more noisy (less precise) than the results of the non-spiking network. However, despite this, the oscillator network in its current configuration is stable even with the spikes adding additional noise into the system.\n",
+    "\n",
+    "It should be noted that the output of the spiking network might differ from the output of the non-spiking network because the network parameters are regenerated (randomized) when a new Nengo simulation is created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10: Experiment!\n",
+    "\n",
+    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, modify the oscillation frequency (try making it negative) to its impact on the output. You can also change the simulation time and see how long the oscillator is stable for!\n",
+    "\n",
+    "Perform these experiments for both the non-spiking and spiking networks, and observe how the additional noise introduced by the spikes affect the performance of the network with relation to the various network and oscillator parameters."
    ]
   }
  ],

--- a/docs/examples/notebooks/05-controlled-oscillator.ipynb
+++ b/docs/examples/notebooks/05-controlled-oscillator.ipynb
@@ -269,7 +269,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 8: Plot the Results:"
+    "## Step 8: Plot the Results"
    ]
   },
   {
@@ -278,11 +278,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(8, 5))\n",
-    "plt.plot(sim.trange(), sim.data[freq_p], 'k--')\n",
-    "plt.plot(sim.trange(), sim.data[output_p])\n",
-    "plt.legend(['Frequency (Hz)', '$x_0$', '$x_1$', '$x_2$'], loc='upper right')\n",
-    "plt.xlabel('Time (s)');"
+    "def plot_results():\n",
+    "    plt.figure(figsize=(8, 5))\n",
+    "    plt.plot(sim.trange(), sim.data[freq_p], 'k--')\n",
+    "    plt.plot(sim.trange(), sim.data[output_p])\n",
+    "    plt.legend(['Frequency (Hz)', '$x_0$', '$x_1$', '$x_2$'], loc='upper right')\n",
+    "    plt.xlabel('Time (s)');\n",
+    "\n",
+    "\n",
+    "plot_results()"
    ]
   },
   {
@@ -302,19 +306,70 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax, ax2, anim = make_anim_controlled_osc(sim.data[output_p][:, 0],\n",
-    "                                              sim.data[output_p][:, 1],\n",
-    "                                              sim.data[freq_p])\n",
-    "ax.set_title('Oscillator')\n",
-    "ax2.set_title('Speed (Hz)')\n",
-    "HTML(anim.to_html5_video())"
+    "def make_anim():\n",
+    "    _, ax, ax2, anim = make_anim_controlled_osc(sim.data[output_p][:, 0],\n",
+    "                                                sim.data[output_p][:, 1],\n",
+    "                                                sim.data[freq_p])\n",
+    "    ax.set_title('Oscillator')\n",
+    "    ax2.set_title('Speed (Hz)')\n",
+    "    return anim\n",
+    "\n",
+    "\n",
+    "HTML(make_anim().to_html5_video())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, try modifying the oscillation frequency input and make the appropriate changes to the scaling factor to see if they have the desired effect. You can also change the simulation time and see how long the oscillator is stable for!"
+    "## Step 9: Spiking Neurons\n",
+    "\n",
+    "The plots above demonstrate the results of a controlled oscillator implemented in a network of non-spiking rectified linear neurons. The network can also be simulated using spiking neurons to illustrate the similarities and differences between a spiking and a non-spiking network.\n",
+    "\n",
+    "Below, we configure the FPGA neural ensemble to use spiking neurons, run the simulation, and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with model:\n",
+    "    fpga_ens.ensemble.neuron_type = nengo.SpikingRectifiedLinear()\n",
+    "\n",
+    "with nengo_fpga.Simulator(model) as sim:\n",
+    "    sim.run(10)\n",
+    "plot_results()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HTML(make_anim().to_html5_video())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plots above show that with spiking neurons, the output of the network is, expectedly, more noisy (less precise) than the results of the non-spiking network. However, despite this, the oscillator network in its current configuration is stable even with the spikes adding additional noise into the system.\n",
+    "\n",
+    "It should be noted that the output of the spiking network differs from the output of the non-spiking network because the network parameters are regenerated (randomized) when a new Nengo simulation is created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10: Experiment!\n",
+    "\n",
+    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, try modifying the oscillation frequency input and make the appropriate changes to the scaling factor to see if they have the desired effect. You can also change the simulation time and see how long the oscillator is stable for!\n",
+    "\n",
+    "Perform these experiments for both the non-spiking and spiking networks, and observe how the additional noise introduced by the spikes affect the performance of the network with relation to the various network and oscillator parameters."
    ]
   }
  ],

--- a/docs/examples/notebooks/06-chaotic-attractor.ipynb
+++ b/docs/examples/notebooks/06-chaotic-attractor.ipynb
@@ -119,7 +119,7 @@
     "        n_neurons=2000,  # The number of neurons to use in the ensemble\n",
     "        dimensions=3,  # 3 dimensions\n",
     "        learning_rate=0,  # No learning for this example\n",
-    "        feedback=1  # Activate the recurrent connection\n",
+    "        feedback=1,  # Activate the recurrent connection\n",
     "    )\n",
     "\n",
     "    # The representational space of the Lorenz attractor is pretty big,\n",
@@ -188,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 8: Plot the Results:"
+    "## Step 8: Plot the Results"
    ]
   },
   {
@@ -197,16 +197,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(8, 12))\n",
-    "plt.subplot(211)\n",
-    "plt.plot(sim.trange(), sim.data[output_p])\n",
-    "plt.legend(['$x_0$', '$x_1$', '$x_2$'], loc='upper right')\n",
-    "plt.xlabel('Time (s)');\n",
+    "def plot_results():\n",
+    "    plt.figure(figsize=(8, 12))\n",
+    "    plt.subplot(211)\n",
+    "    plt.plot(sim.trange(), sim.data[output_p])\n",
+    "    plt.legend(['$x_0$', '$x_1$', '$x_2$'], loc='upper right')\n",
+    "    plt.xlabel('Time (s)');\n",
     "\n",
-    "# Make 3D plot\n",
-    "ax = plt.subplot(212, projection=Axes3D.name)\n",
-    "ax.plot(*sim.data[output_p].T)\n",
-    "ax.set_title('3D Plot');"
+    "    # Make 3D plot\n",
+    "    ax = plt.subplot(212, projection=Axes3D.name)\n",
+    "    ax.plot(*sim.data[output_p].T)\n",
+    "    ax.set_title('3D Plot');\n",
+    "\n",
+    "\n",
+    "plot_results()"
    ]
   },
   {
@@ -224,18 +228,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax, anim = make_anim_chaotic(sim.data[output_p][:, 0],\n",
-    "                                  sim.data[output_p][:, 1],\n",
-    "                                  sim.data[output_p][:, 2],\n",
-    "                                  ms_per_frame=20)\n",
-    "HTML(anim.to_html5_video())"
+    "def make_anim():\n",
+    "    _, _, anim = make_anim_chaotic(sim.data[output_p][:, 0],\n",
+    "                                   sim.data[output_p][:, 1],\n",
+    "                                   sim.data[output_p][:, 2],\n",
+    "                                   ms_per_frame=20)\n",
+    "    return anim\n",
+    "\n",
+    "\n",
+    "HTML(make_anim().to_html5_video())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, modify the parameters of the Lorenz attractor to see what effect it has on the shape of it. Be sure to run the simulation multiple times and observe if you can see any identical patterns (because the attractor is chaotic, every run should be different)."
+    "## Step 9: Spiking Neurons\n",
+    "\n",
+    "The plots above show the output of the Lorenz attractor network implemented with non-spiking rectified linear neurons. The network can also be simulated using spiking neurons to illustrate the similarities and differences between a spiking and a non-spiking network.\n",
+    "\n",
+    "Below, we configure the FPGA neural ensemble to use spiking neurons, run the simulation, and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with model:\n",
+    "    fpga_ens.ensemble.neuron_type = nengo.SpikingRectifiedLinear()\n",
+    "\n",
+    "with nengo_fpga.Simulator(model) as sim:\n",
+    "    sim.run(20)\n",
+    "plot_results()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HTML(make_anim().to_html5_video())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plots above show that with spiking neurons, the output of the network is, expectedly, more noisy (less precise) than the results of the non-spiking network. However, despite this, the chaotic attractor network in its current configuration is stable, and exhibits the expected behaviour of the Lorenz attractor.\n",
+    "\n",
+    "It should be noted that the output of the spiking Lorenz attractor network differs from that of the non-spiking network because of two factors. First, every time the Nengo simulator is created, the network parameters are regenerated (randomized). Second, because the dynamics of the Lorenz attractor are extremely sensitive to the initial conditions of the network (which is what makes it chaotic), even if the spiking and non-spiking networks were generated with the same parameters, the additional noise introduced by the spikes cause the spiking output to diverge from the trajectory of the non-spiking network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10: Experiment!\n",
+    "\n",
+    "Try playing around with the number of neurons in the FPGA ensemble as well as the synaptic time constant (`tau`) to see how it effects performance (e.g., observe how changing these numbers affect the stability of the oscillator)! Additionally, modify the parameters of the Lorenz attractor to see what effect it has on the shape of it. Be sure to run the simulation multiple times and observe if you can see any identical patterns (because the attractor is chaotic, every run should be different).\n",
+    "\n",
+    "Explore the deterministic (yet chaotic) nature of the Lorenz attractor network, by constructing the `FpgaPesEnsembleNetwork` with the `seed` parameter, and re-running this notebook. You should observe because the Lorenz attractor is deterministic, with a pre-set seed, every run of the notebook will produce identical results. However, because the attractor is chaotic (very sensitive to the recurrent activity in the network), the additional noise introduced by the spikes cause it to follow a different trajectory from the non-spiking network."
    ]
   }
  ],

--- a/docs/examples/notebooks/anim_utils.py
+++ b/docs/examples/notebooks/anim_utils.py
@@ -102,8 +102,16 @@ def make_anim_controlled_osc(
     axis_limits = max(max(np.absolute(x)), max(np.absolute(y))) * 1.2
     ax.set_xlim(-axis_limits, axis_limits)
     ax.set_ylim(-axis_limits, axis_limits)
-    ax.set_xticks(np.linspace(-int(axis_limits), int(axis_limits), 5))
-    ax.set_yticks(np.linspace(-int(axis_limits), int(axis_limits), 5))
+    ax.set_xticks(np.linspace(
+        -np.round(axis_limits, 0),
+        np.round(axis_limits, 0),
+        num=5)
+    )
+    ax.set_yticks(np.linspace(
+        -np.round(axis_limits, 0),
+        np.round(axis_limits, 0),
+        num=5)
+    )
 
     # Make the initial line collection object
     lsegs = LineCollection(make_2d_segments([0], [0]), cmap=cmap, lw=lw)
@@ -115,8 +123,9 @@ def make_anim_controlled_osc(
 
     # Sidebar plot
     ax2 = plt.subplot(gs[1])
-    ax2.set_ylim(-axis_limits, axis_limits)
-    ax2.set_yticks(np.linspace(-int(axis_limits), int(axis_limits), 5))
+    speed_limits = max(np.absolute(w)) * 1.2
+    ax2.set_ylim(-speed_limits, speed_limits)
+    ax2.set_yticks(np.linspace(-int(speed_limits), int(speed_limits), num=5))
     ax2.set_xticks([])
     ax2.yaxis.set_label_position("right")
     ax2.yaxis.tick_right()


### PR DESCRIPTION
- Added spiking network versions to the  integrator, simple oscillator, controlled oscillator, and chaotic attractor notebooks.
- Modified controlled oscillator plot so that  it would compute appropriate axis ticks even if the outputs were < 1. Previously, in  this situation, there would only be one axis  tick at 0.
- Modified controlled oscillator speed plot  so that the axis limits were dependent on the speed output, not the oscillator output.
- Fixed pylint and flake8 errors with the notebooks.

**Motivation and context:**
The feedback notebooks did not demonstrate it working with spiking neurons. This PR addresses this concern.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

**How has this been tested?**
Notebooks have been built on my local system. Everything seems to be as expected. Static CI script has also been run on the code to address flake8/pylint issues.
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
Start by building the docs and looking at the integrator notebook.
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have tested this with all supported devices.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
