### PR TITLE
Add more detail to remote termination

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Release History
   (`#46 <https://github.com/nengo/nengo-fpga/pull/46>`__)
 - Added spiking to oscillator notebook examples.
   (`#49 <https://github.com/nengo/nengo-fpga/pull/49>`__)
+- Added More detail to remote termination signals.
+  (`#61 <https://github.com/nengo/nengo-fpga/pull/61>`__)
 
 **Changed**
 
@@ -51,7 +53,7 @@ Release History
 - Switch to remote doc script that tracks nengo-bones.
   (`#60 <https://github.com/nengo/nengo-fpga/pull/60>`__)
 - Switch to abrgl for CI scripts.
-  (`#60 <https://github.com/nengo/nengo-fpga/pull/62>`__)
+  (`#62 <https://github.com/nengo/nengo-fpga/pull/62>`__)
 
 **Fixed**
 

--- a/nengo_fpga/networks/fpga_pes_ensemble_network.py
+++ b/nengo_fpga/networks/fpga_pes_ensemble_network.py
@@ -426,7 +426,7 @@ class FpgaPesEnsembleNetwork(nengo.Network):
                 )
         logger.info("Terminating SSH thread")
 
-    def connect(self):
+    def connect(self):  # noqa: C901
         """Connect to FPGA via SSH if applicable"""
 
         # Function does nothing if FPGA configuration not found in config file
@@ -498,11 +498,17 @@ class FpgaPesEnsembleNetwork(nengo.Network):
                 "Did not receive connection from board within "
                 + "specified timeout (%fs)." % self.connect_timeout
             )
+
         if self.recv_buffer[0] < 0.0:
             # Received a "terminate client" packet from the board, terminate the
             # Nengo simulation.
+            reason = ""
+            if self.recv_buffer[0] <= -20:
+                reason = "Unable to load FPGA driver!"
+            elif self.recv_buffer[0] <= -10:
+                reason = "Unable to acquire FPGA resource lock!"
             self.close()
-            raise RuntimeError("Simulation terminated by FPGA board.")
+            raise RuntimeError(reason + " Simulation terminated by FPGA board.")
 
     def process_ssh_output(self, data):
         """Clean up the data stream coming back over ssh if applicable"""


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

There was no information given when the device side shutdown the simulation. Now there is

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

- nengo/nengo-pynq#15
- nengo/nengo-de1#8
- (indirectly) nengo/nengo-fpga#55 tests will need to be updated to reflect the change

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Manually tested various conditions

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have tested this with all supported devices.
- N/A I have added tests to cover my changes.
- N/A I have run the test suite locally and all tests passed.
