### PR TITLE
Minor fixes to codebase

### DIFF
--- a/nengo_fpga/id_extractor.py
+++ b/nengo_fpga/id_extractor.py
@@ -274,7 +274,7 @@ def main(fpga_name):
     fpga.connect()
     fpga.recv_id()
 
-    id_str = f"Found board ID: {fpga.id_int:#016X}"
+    id_str = f"Found board ID: {fpga.id_int:#018X}"
 
     with open(filename, "w", encoding="ascii") as file:
         file.write(id_str)

--- a/nengo_fpga/tests/test_simulator.py
+++ b/nengo_fpga/tests/test_simulator.py
@@ -17,7 +17,7 @@ def test_init(mocker):
     dt = 1  # Check kwargs are passed through
     sim = Simulator(nengo_net, dt=dt)
 
-    assert sim.fpga_networks_list == []
+    assert not sim.fpga_networks_list
     super_mock.assert_called_once_with(nengo_net, dt=dt)
     super_mock.reset_mock()
 


### PR DESCRIPTION
- Fixed hex padding for f-string
- Fixed pylint error

**Motivation and context:**
Fixes erroneous ID string length in ID script. Also address pylint error when comparing to empty lists.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [NA] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [x] I have tested this with all supported devices.
- [NA] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
